### PR TITLE
remove unmantained aur brave package

### DIFF
--- a/ufscar-hpc/daily.1.txt
+++ b/ufscar-hpc/daily.1.txt
@@ -24,7 +24,8 @@ linux-next-git
 icecat
 
 # Issue 616
-brave
+# seems unmaintained on aur, as we already have brave-bin
+#brave
 
 # Issue 640
 rpcs3-git


### PR DESCRIPTION
its unmantained on aur for some months now:

from aur/brave:

>Appeal for co-maintainers: I'd be very interested if anybody else out there was willing to take this on. Long term I have an eye on moving it to [community], but there are a number of road blocks to overcome before that can happen: some upstream and some local to this packaging. The PKGBUILD needs a bit of work, and even without trying to clean it up maintaining Chromium builds of any kind is quite a bit of work. I adopted this with the aim of shepherding it until I feel comfortable pulling it into [community], but until then I would love if one or more co-maintainers would jump on here.

>Feel free to send patches in comments, via email, or as PRs to [this repository](https://github.com/alerque/aur/tree/master/brave).