### PR TITLE
Add -git version of linux-mainline-anbox

### DIFF
--- a/garuda-cluster/afternoon.txt
+++ b/garuda-cluster/afternoon.txt
@@ -10,3 +10,4 @@ linux-vfio-lts
 
 # Issue 944
 linux-mainline-anbox
+linux-mainline-anbox-git


### PR DESCRIPTION
The critical `CONFIG_ANDROID_BINDER_DEVICES` flag is set to `””` instead of the correct `”/dev/binder”` which results in failure of Anbox to recognize that it’s enabled. So I submitted a fixed -git version of this kernel to the AUR to correct this and therefore also hope to see it in Chaotic.