### PR TITLE
Fix link to banned packages in request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-package-requests.yml
+++ b/.github/ISSUE_TEMPLATE/new-package-requests.yml
@@ -60,7 +60,7 @@ body:
   - type: checkboxes
     attributes:
       label: "Have you read the README to ensure this package is not banned?"
-      description: "https://github.com/chaotic-aur/packages#banished-and-rejected-packages"
+      description: "https://github.com/chaotic-aur/packages#banished-and-rejected-packages-"
       options:
         - label: "YES!"
           required: true


### PR DESCRIPTION
Better to fix README.md, but I'm unsure how.