### PR TITLE
add most recent version of Waterfox

### DIFF
--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -2032,3 +2032,6 @@ swayfx
 
 # Issue 2128
 cassowary
+
+# Issue 2134
+waterfox-g-bin


### PR DESCRIPTION
Add current generation of Waterfox

The previous generations are already in Chaotic AUR (and are still maintained)
