### PR TITLE
Fix simple-mtpfs

### DIFF
--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -1187,7 +1187,7 @@ google-chrome-dev
 xbanish
 
 # Issue 976
-śimple-mtpfs
+simple-mtpfs
 
 # Issue 978
 termv-git


### PR DESCRIPTION
Package names shouldn't have accent.  Fixes #1410.