### PR TITLE
Drop packages that were added to extra/community

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -772,7 +772,6 @@ nchat-git
 lightspark-git
 
 # Issue 1943
-endeavour
 endeavour-git
 
 # Issue 1944

--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -259,9 +259,6 @@ davfs2
 # Issue 1363
 asusctl-git
 
-# Issue 1364
-gnome-console
-
 # Issue 1372
 duplicacy
 

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -13,7 +13,6 @@ jitsi-meet-desktop
 mendeleydesktop-bundled
 ms-office-online
 onlyoffice-bin
-openh264
 python-pypresence # (dep rare)
 rare
 spotify

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -124,7 +124,6 @@ firefox-extension-plasma-integration
 fish-autopair
 flameshot-git
 garuda-downloader-git
-hblock
 hw-probe
 imagewriter
 lib32-nvidia-390xx-utils

--- a/ufscar-hpc/daily.1.txt
+++ b/ufscar-hpc/daily.1.txt
@@ -20,7 +20,6 @@ ayatana-indicator-datetime
 calligra-git
 kwaterfoxhelper
 nvm
-python-grpcio-tools
 python-pympv
 python-sphinx-automodapi
 tweeny

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -15,7 +15,6 @@ soapysdrplay-git
 android-emulator
 android-sdk
 android-studio
-bear
 chromium-widevine
 digilent.adept.runtime
 digilent.adept.utilities
@@ -73,7 +72,6 @@ powerpill
 python3-memoizedb
 python3-xcgf
 python3-xcpf
-guestfs-tools
 dumpasn1
 dieharder
 bluespec-contrib-git
@@ -464,9 +462,6 @@ jre8
 # Issue 363
 zsh-theme-powerlevel10k-git
 
-# Issue 364
-gst-rtsp-server
-
 # Issue 368
 oh-my-zsh-git
 
@@ -688,7 +683,6 @@ apostrophe
 aic94xx-firmware
 dmenu-height
 makemkv
-j4-dmenu-desktop
 farbfeld
 
 # Issue 474

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -610,9 +610,6 @@ sourcetrail
 # Issue 447
 spot-client
 
-# Issue 448
-ytfzf
-
 # Issue 449
 gdm-prime
 

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -12,7 +12,6 @@ python-textx  # for prjxray-tools-git
 python-fasm-git  # for prjxray-tools-git
 prjxray-db-git
 prjxray-tools-git
-python-crcmod
 yosys-git
 
 # Ham radio stuff
@@ -26,7 +25,6 @@ gpredict
 # Pedro
 android-sdk-platform-tools
 android-studio-launcher
-android-udev
 bytecode-viewer
 ca-certificates-icp_br
 chaotic-keyring
@@ -62,9 +60,6 @@ python-telegram-bot # (dep python-telegram-send)
 python-telegram-send
 quartus-130
 ripcord-arch-libs
-ruby-coderay # (dep logstalgia)
-ruby-method_source # (dep logstalgia)
-ruby-pry # (dep logstalgia)
 sdl2_compat12-git
 shntool # (dep split2flac)
 spectral-matrix-git
@@ -517,7 +512,6 @@ zlib-ng-git
 # Issue 497
 mu-editor
 pigpio # (dep mu-editor)
-python-asttokens # (dep thonny)
 python-colorzero # (dep mu-editor)
 python-gpiozero # (dep mu-editor)
 python-guizero # (dep mu-editor)
@@ -584,9 +578,6 @@ gnome-network-displays
 
 # Issue 625
 gtk3-nocsd-git
-
-# Issue 626
-freeplane
 
 # Issue 627
 github-desktop
@@ -711,9 +702,6 @@ greetd-tuigreet
 
 # Issue 716
 find-the-command
-
-# Issue 717
-kooha
 
 # Issue 718
 qview
@@ -841,10 +829,6 @@ saxon-he # (dep scilab)
 #scilab
 xalan-java # (dep scilab)
 xerces2-java # (dep scilab)
-
-# Issue 772
-dnf
-libdnf # (dep dnf)
 
 # Issue 773
 libpdfium-nojs # (dep yacreader)
@@ -1208,7 +1192,6 @@ libspectrum # (dep fuse-emulator)
 # Issue 991
 deadbeef
 deadbeef-git
-libdispatch
 
 # Issue 992
 gzdoom
@@ -1382,9 +1365,6 @@ graphite-cursor-theme-git
 # Issue 1098
 rpi-imager
 
-# Issue 1099
-wgcf
-
 # Issue 1100
 papirus-folders-gui
 
@@ -1393,10 +1373,6 @@ sayonara-player-git
 
 # Issue 1104
 pcloudcc-git
-
-# Issue 1105
-python-av
-python-torchvision
 
 # Issue 1107
 libpamac-nosnap
@@ -1407,9 +1383,6 @@ dosbox-x
 
 # Issue 1112
 iota-firefly-wallet
-
-# Issue 1113
-stern
 
 # Issue 1114
 bulky
@@ -1423,9 +1396,6 @@ mint-themes-legacy
 # Issue 1118
 mcpelauncher-linux-git
 mcpelauncher-ui-git
-
-# Issue 1123
-tectonic
 
 # Issue 1125
 sonarr

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -404,7 +404,6 @@ wine-x64 # Issue 330
 winbox64 # Issue 330
 wine-stable # Issue 311
 gdm-plymouth # Issue 401
-plymouth # Issue 401 (dep gdm-plymouth-prime)
 
 ## Not building on ufscar
 # Issue 322


### PR DESCRIPTION
Double checked that packages dropped in this PR are in extra or community.   See #2358.

Also dropping `python-av` because it was added as a dependency for `python-torchvision` and no longer used by any other packages.

Related issues: #448 #626 #717 #772 #1099 #1105 #1113 #1123 #1364