### PR TITLE
Drop packages that were removed from AUR

### DIFF
--- a/CatBuilder/hourly.txt
+++ b/CatBuilder/hourly.txt
@@ -1,7 +1,6 @@
 alvr
 android-studio-canary
 epson-inkjet-printer-escpr2
-ffmpeg-vulkan
 google-chrome-beta
 hotspot
 kddockwidgets # (dep hotspot)

--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -8,7 +8,6 @@ ananicy-rules # (dep ananicy-cpp-git)
 anbox-image-houdini-rooted
 arch-deployer-git
 babl-git # (dep gimp-git)
-binfmt-qemu-static
 brave-nightly-bin
 btop-git
 cachyos-ananicy-rules
@@ -198,7 +197,6 @@ rustdesk-nightly # (dep remmina-plugin-rustdesk)
 spotify-adblock-git
 
 # Issue 1034
-aura-fetch-git
 bitfetch-git
 freshfetch-git
 novafetch-git

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -2,7 +2,6 @@
 bitwig-studio
 brave-bin
 dissenter-browser-bin
-exe-thumbnailer
 firefox-extension-xdm-browser-monitor
 freedownloadmanager
 freeoffice
@@ -144,7 +143,6 @@ flat-remix
 flat-remix-gtk
 fluent-gtk-theme-git
 fluent-icon-theme-git
-gnome-control-center-x11-scaling
 gnome-shell-extension-gnome-ui-tune-git
 gnome-shell-extension-pop-shell-git
 kali-themes
@@ -190,7 +188,6 @@ itch-setup-bin
 # Zoeruda
 cmst-git
 connman-git
-connman-gtk-git
 
 # Alexjp
 bcache-tools

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -17,7 +17,6 @@ plasma5-applets-netspeed
 plasma5-applets-window-appmenu
 plasma5-applets-window-title
 resvg
-rootactions-servicemenu
 sweet-folders-icons-git # (dep sweet-theme-full-git)
 sweet-kde-theme-git # (dep sweet-theme-full-git)
 sweet-theme-full-git
@@ -79,8 +78,6 @@ wlsunset
 wob
 
 # Wayfire
-greetd
-greetd-qtgreet
 wayfire-desktop-git
 wayfire-plugins-extra
 wayfire
@@ -180,7 +177,6 @@ zsync2-git
 r8168-dkms
 realtek-firmware
 rtl8192cu-fixes-git
-rtl8814au-aircrack-dkms-git
 rtl88x2bu-dkms-git
 rtl88x2ce-dkms
 rtl88xxau-aircrack-dkms-git

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -363,7 +363,6 @@ graphite-mozilla
 intellij-idea-ultimate-edition
 lib32-fltk # (dep)
 lib32-libwmf
-lib32-numactl
 lib32-openexr
 lib32-zbar
 ncnn-git # (dep waifu2x-ncnn-vulkan-git)
@@ -510,10 +509,6 @@ dwm
 dwm-git
 st # (dep dwm)
 
-# Issue 383
-#vte3-notification broken now, using below instead
-vte-ng
-
 # Issue 385
 linux-firmware-git
 
@@ -619,7 +614,6 @@ mozc-ut-common
 
 # Isse 454
 woeusb
-woeusb-gui
 
 # Issue 457
 webkit2gtk-unstable
@@ -669,16 +663,11 @@ vala-panel-appmenu-registrar-git
 
 # Issue 471
 filebot
-masterpdfeditor-libs-included
 feem
-
-# Issue 472
-chromium-ublock-origin
 
 # Issue 473
 apostrophe
 aic94xx-firmware
-dmenu-height
 makemkv
 farbfeld
 
@@ -752,9 +741,6 @@ bluej
 libvterm-0.1 # (dep neovim-git)
 neovim-git
 
-# Issue 503
-lightcord-bin
-
 # Issue 504
 blueprint-compiler-git # (dep gfeeds-git)
 gfeeds-git
@@ -764,7 +750,6 @@ python-syndom-git # (dep gfeeds-git)
 llvm-proton-bin
 
 # Issue 538
-godot-beta-bin
 godot-git:https://github.com/chaotic-aur/pkgbuild-godot-git.git
 
 # Issue 558
@@ -804,9 +789,6 @@ ttf-symbola
 xfce4-docklike-plugin
 xplayer
 xplayer-plparser # (xplayer)
-
-# Issue 594
-chrome-gnome-shell
 
 # Issue 595
 plex-media-server
@@ -1203,9 +1185,6 @@ sidequest-bin
 
 # Issue 1663
 asix-ax88179-dkms
-
-# Issue 1677
-nerd-fonts-hack
 
 # Issue 1678
 broadcom-bt-firmware-git

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -80,7 +80,6 @@ gamescope-git:https://github.com/Frogging-Family/gamescope-git.git
 goverlay-git
 mangohud:https://aur.archlinux.org/mangohud.git # (dep lutris-wine-git)
 mangohud-git
-mangohud-wayland
 material-kwin-decoration-git
 neofrog-git:https://github.com/Frogging-Family/neofrog-git.git
 spirv-tools-tkg-git:https://github.com/Frogging-Family/spirv-tools-git.git
@@ -113,9 +112,6 @@ munt # (dep dosbox-staging)
 noti
 nqp
 nteract-bin
-opencolorio-qfix # (dep blender-git)
-openimageio-qfix # (dep blender-git)
-openshadinglanguage-qfix # (dep blender-git)
 openxray
 popura-git
 powder-toy-git
@@ -286,7 +282,6 @@ fancontrol-gui-git
 flycast
 game-devices-udev
 gamehub
-gamerworld
 godot-headless-bin # (dep luxtorpeda-git)
 gwe
 heroic-games-launcher-bin
@@ -294,7 +289,6 @@ hypnotix
 ialauncher-git
 input-remapper-git
 keyboard-visualizer-git
-latencyflex # (dep lutris-wine-git)
 legendary
 lib32-vkbasalt # (dep lutris-wine-git)
 libliftoff-git # (dep gamescope-git)
@@ -320,7 +314,6 @@ replay-sorcery
 reshade-shaders-git
 retroarch-autoconfig-udev-git
 retrolink-git
-rpcs3
 sc-controller
 stacer
 steamtinkerlaunch
@@ -332,7 +325,6 @@ xboxdrv
 xone-dongle-firmware # (dep xone-dkms-git)
 xone-dkms-git
 xone-dkms
-xow
 xow-git
 xpadneo-dkms-git
 xpadneo-dkms
@@ -345,7 +337,6 @@ chromaprint-fftw
 davs2
 decklink-sdk
 flite1
-flite1-patched
 highway-git # (dep libjxl-git)
 lensfun-git
 libjxl-git
@@ -696,9 +687,6 @@ peazip-gtk2-bin
 peazip-qt5
 zpaq # (dep peazip-gtk2-bin)
 
-# Issue 714
-greetd-tuigreet
-
 # Issue 716
 find-the-command
 
@@ -752,9 +740,6 @@ rider
 # Issue 741
 apparmor-git
 celluloid-git
-
-# Issue 742
-sneedacity-git
 
 # Issue 743
 qtile-git
@@ -861,9 +846,6 @@ proftpd
 # Issue 786
 tuner
 
-# Issue 798
-libxft-bgra
-
 # Issue 789
 htim
 
@@ -872,9 +854,6 @@ vim-slime-git
 
 # Issue 791
 vim-vimwiki
-
-# Issue 795
-netflix-git
 
 # Issue 798
 silos
@@ -1038,9 +1017,6 @@ grub2-signing-extension
 # Issue 901
 losslesscut-bin
 
-# Issue 903
-musixmatch-bin
-
 # Issue 904
 obs-nvfbc
 
@@ -1079,9 +1055,6 @@ dasel
 
 # Issue 917
 polychromatic
-
-# Issue 918
-nvidia-utils-keylase
 
 # Issue 922
 chromium-snapshot-bin
@@ -1137,9 +1110,6 @@ autokey-qt
 anki
 python-mypy-protobuf # (dep anki)
 python-springcase # (dep anki)
-
-# Issue 962
-osh 
 
 # Issue 964
 rapidyaml-git # (dep pcsx2-git, also creates python-rapidyaml-git)
@@ -1409,7 +1379,6 @@ qbittorrent-enhanced
 leagueoflegends-git
 lib32-unixodbc # (dep leagueoflegends-git)
 wine-lol
-wine-lol-glibc
 
 # Issue 1141
 jamesdsp-pulse
@@ -1571,9 +1540,6 @@ stockfish-git
 
 # Issue 1481
 spice-guest-tools-windows
-
-# Issue 1486
-kwallet-secrets
 
 # Issue 1500
 phoenicis-playonlinux


### PR DESCRIPTION
Packages have been double checked to remove false positives from my original list.  Some packages use pkgbase and generate differently named packages.  See #2358.

`greetd` is technically still in the AUR, but there is a pending deletion request because it has been upgraded to community.  Fixes #2362.

Remove ffmpeg-vulkan. Fixes #1209.

Related issues: #383 #472 #503 #594 #714 #742 #795 #798 #903 #918 #962 #1486 #1677