### PR TITLE
Fix and drop broken packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -181,7 +181,6 @@ mkosi-git
 
 # Issue 759
 tenacity-git
-wxwidgets-dev-light # (dep tenacity-git)
 
 # Issue 819
 goodvibes

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -38,7 +38,7 @@ webapp-manager
 
 # Mycroft
 fann
-mimic
+mimic1
 mycroft-core
 mycroft-gui-git
 plasma5-applets-mycroft-git
@@ -105,7 +105,7 @@ bass-fish
 bindfs
 buttermanager
 caffeine
-caja-pdf-tools-git
+nautilus-pdf-tools-git:https://aur.archlinux.org/nautilus-pdf-tools-git.git # {nautilus,nemo,caja}-pdf-tools-git
 ckbcomp
 debtap
 droidcam

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -153,7 +153,6 @@ pace
 pacui:https://github.com/excalibur1234/pacui.git
 pamac-aur
 paru
-performance-tweaks
 plymouth-git
 preload
 prelockd

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -338,7 +338,6 @@ pod2man # (dep auracle-git)
 xfce4-panel-compiz
 
 # Issue 326
-dotnet-core-bin # (dep powershell ryujinx-git)
 powershell
 
 # Issue 347
@@ -464,9 +463,6 @@ zsh-theme-powerlevel10k-git
 # Issue 368
 oh-my-zsh-git
 
-# Issue 360
-amdgpu-pro-installer
-
 # Issue 306
 omnisharp-roslyn
 
@@ -497,7 +493,7 @@ kawaii-player
 # Issue 379
 ckb-next
 osu-lazer
-tuxedo-control-center
+tuxedo-control-center-bin
 tuxedo-keyboard-dkms
 
 # Issue 380
@@ -570,7 +566,6 @@ arm-linux-gnueabi-binutils
 arm-linux-gnueabi-gcc
 
 # Issue 423
-aws-cli-v2-bin
 aws2-wrap
 tflint
 
@@ -609,8 +604,8 @@ spot-client
 gdm-prime
 
 # Issue 452
-ibus-mozc-ut
-mozc-ut-common
+ibus-mozc
+mozc-ut
 
 # Isse 454
 woeusb
@@ -1241,9 +1236,8 @@ ttf-aller
 audiowide-font
 ttf-bangers
 ttf-djb-zora-prints-fonts
-xorg-font-utils # (dep ttf-geosans-light ttf-iskpota)
+xorg-font-utils # (dep ttf-geosans-light)
 ttf-geosans-light
-ttf-iskpota
 fonts-kalam
 ttf-pacifico
 
@@ -1449,7 +1443,7 @@ notable-bin
 youtubedl-gui
 
 # Issue 1914
-python-pypdf2 # (dep bookletimposer caja-pdf-tools-git krop)
+python-pypdf2 # (dep bookletimposer nautilus-pdf-tools-git krop)
 bookletimposer
 
 # Issue 1920
@@ -1623,6 +1617,5 @@ anaconda
 fluent-reader
 fnott
 java-openjdk-ea-bin
-kite
 telegram-desktop-bin-dev
 ytfzf-git

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -8,14 +8,13 @@ prjtrellis-db-git
 nextpnr-git
 prjapicula
 prjoxide-git
-python-textx  # for prjxray-tools-git
-python-fasm-git  # for prjxray-tools-git
+python-textx  # for prjxray-git
+python-fasm-git  # for prjxray-git
 prjxray-db-git
-prjxray-tools-git
+prjxray-git:https://aur.archlinux.org/prjxray-git.git # prjxray-tools-git python-prjxray-git
 yosys-git
 
 # Ham radio stuff
-wxgtk2.8  # for trustedqsl
 hamradio-menus  # for trustedqsl, gpredict
 trustedqsl
 qlog-git
@@ -106,7 +105,6 @@ jupyter-metakernel
 koka-bin
 languageclient-neovim
 lua-format
-manim
 moarvm
 munt # (dep dosbox-staging)
 noti
@@ -119,15 +117,11 @@ pup
 python-blis # (dep python-spacy)
 python-catalogue # (dep python-spacy)
 python-langcodes # (dep python-spacy)
-python-mainimpango # (dep manim)
-python-moderngl-window # (dep manim)
 python-multipledispatch # (dep python-pyrr)
 python-murmurhash # (dep python-spacy)
 python-pathlib # (dep python-spacy)
 python-plac # (dep python-spacy)
 python-preshed # (dep python-spacy)
-python-pydub # (dep manim)
-python-pyrr # (dep manim)
 python-spacy
 python-srsly # (dep python-spacy)
 python-thinc # (dep python-spacy)
@@ -164,7 +158,6 @@ contractor-git
 elementary-icon-theme-git
 gala-git
 glib2-selinux
-granite-git
 gtk-theme-elementary-git
 kitty-git
 libayatana-common # (dep ayatana-*)
@@ -192,37 +185,33 @@ wezterm-git
 # vim-extension
 nvim-yarp-git
 vim-coc-git
-vim-coc-rust-analyzer-git
-vim-coc-flutter-git 
 vim-coc-clangd-git 
 vim-coc-css-git
-vim-coc-html-git 
-vim-coc-json-git
-vim-coc-pairs-git
-vim-coc-pyright-git
-vim-coc-sh-git 
-vim-coc-tsserver-git
-vim-coc-vimlsp-git
-vim-coc-yaml-git
 vim-coc-deno-git
-vim-coc-java-git
-vim-coc-go-git
-vim-coc-syntax-git 
-vim-coc-tag-git
-vim-coc-dictionary-git
-vim-coc-word-git 
-vim-coc-emoji-git
-vim-coc-explorer-git
-vim-coc-git-git
-vim-coc-highlight-git
-vim-coc-lists-git
-vim-coc-marketplace-git
-vim-coc-tabnine-git
-vim-coc-snippets-git
-vim-coc-htmlhint-git
 vim-coc-diagnostic-git
 vim-coc-eslint-git
+vim-coc-explorer-git
+vim-coc-flutter-git
+vim-coc-git-git
+vim-coc-go-git
+vim-coc-highlight-git
+vim-coc-html-git
+vim-coc-htmlhint-git
+vim-coc-java-git
+vim-coc-json-git
+vim-coc-lists-git
+vim-coc-marketplace-git
+vim-coc-pairs-git
+vim-coc-pyright-git
+vim-coc-rust-analyzer-git
+vim-coc-sh-git
+vim-coc-snippets-git
+vim-coc-sources-git # vim-coc-{dictionary,emoji,syntax,tag,word}-git
+vim-coc-tabnine-git
+vim-coc-tsserver-git
 vim-coc-vetur-git 
+vim-coc-vimlsp-git
+vim-coc-yaml-git
 vim-coc-zsh-git
 
 
@@ -444,9 +433,6 @@ nginx-mainline-mod-headers-more
 nginx-mainline-mod-lua
 nginx-mainline-mod-ndk
 nginx-mainline-mod-njs
-
-# Issue 513
-protonvpn-cli-ng
 
 # Issue 511
 swaylock-effects
@@ -782,9 +768,7 @@ gnome-shell-performance
 mutter-performance
 
 # Issue 766
-gdcm # (dep itk-snap)
-insight-toolkit4 # (dep itk-snap)
-itk-snap
+itk-snap-bin
 
 # Issue 769
 sublime-text-3
@@ -867,7 +851,7 @@ gtk-gnutella-git
 gtk-gnutella
 
 # Issue 802
-quassel-git
+quassel:https://aur.archlinux.org/quassel.git # quassel-git, etc
 
 # Issue 803
 fzf-tab-git
@@ -1034,11 +1018,6 @@ superslicer-profiles-git
 
 # Issue 910
 keepassxc-git
-
-# Issue 911
-ferdi
-ferdi-git
-pnpm # (dep ferdi cider cider-git)
 
 # Issue 912
 git-bug-git


### PR DESCRIPTION
Continuing with #2358...  If preferred, I can make future PRs smaller.

Drops:

* amdgpu-pro-installer # [aur](https://aur.archlinux.org/pkgbase/amdgpu-pro-installer) – recurring kernel issues
* aws-cli-v2-bin – in community
* dotnet-core-bin – in community
* ferdi-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/ferdi-git.log), [aur](https://aur.archlinux.org/packages/ferdi-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+ferdi-git) – deleted from AUR, source unavailable
* granite-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/granite-git.log), [aur](https://aur.archlinux.org/packages/granite-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+granite-git) – granite7 is in community
* kite # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/kite.log), [aur](https://aur.archlinux.org/packages/kite), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+kite) – deleted from AUR, source unavailable
* ttf-iskpota # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/ttf-iskpota.log), [aur](https://aur.archlinux.org/packages/ttf-iskpota), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+ttf-iskpota) – deleted from AUR, source unavailable
* manim # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/manim.log), [aur](https://aur.archlinux.org/packages/manim) – missing dependencies, drop for now
* mimic # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/mimic.log), [aur](https://aur.archlinux.org/packages/mimic), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+mimic) – no longer needed, dependency changed to mimic1
* performance-tweaks – duplicate entries. Remove one, leave the other.
* protonvpn-cli-ng – merged protonvpn-cli (included elsewhere)
* wxgtk2.8 # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/wxgtk2.8.log), [aur](https://aur.archlinux.org/packages/wxgtk2.8), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+wxgtk2.8) – no longer needed dependency
* wxwidgets-dev-light # [aur](https://aur.archlinux.org/pkgbase/wxwidgets-dev-light) – no longer needed dependency

Renames and Fixes:

* caja-pdf-tools-git # [aur](https://aur.archlinux.org/packages/caja-pdf-tools-git) – pkgbase: nautilus-pdf-tools-git
* ibus-mozc-ut – merged ibus-mozc
* itk-snap – merged itk-snap-bin
* mycroft-core # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/mycroft-core.log), [aur](https://aur.archlinux.org/packages/mycroft-core), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+is:closed+mycroft-core) – change dependency (mimic1)
* mozc-ut-common – merged mozc-ut
* prjxray-tools-git # [aur](https://aur.archlinux.org/packages/prjxray-tools-git) – pkgbase: prjxray-git
* quassel-git # [aur](https://aur.archlinux.org/packages/quassel-git) – pkgbase: quassel
* tuxedo-control-center – renamed tuxedo-control-center-bin
* vim-coc-{dictionary,emoji,syntax,tag,word}-git – pkgbase: vim-coc-sources-git

Related issues: #360 #513 #911