### PR TITLE
Fix and drop broken packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -10,7 +10,7 @@ arch-deployer-git
 babl-git # (dep gimp-git)
 brave-nightly-bin
 btop-git
-cachyos-ananicy-rules
+cachyos-ananicy-rules # ananicy-rules
 catch2-git # (dep waybar-hyprland-git)
 cfs-zen-tweaks
 chkrootkit

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -147,11 +147,10 @@ gnome-shell-extension-gnome-ui-tune-git
 gnome-shell-extension-pop-shell-git
 kali-themes
 ksmoothdock
-kvantum-theme-layan-git
 kvantum-theme-matcha-git
 kvantum-theme-vimix-git
 layan-gtk-theme-git
-layan-kde-git
+layan-kde-git:https://aur.archlinux.org/layan-kde-git.git # layan-kde-git kvantum-theme-layan-git
 loginized
 matcha-gtk-theme-git
 mcmojave-circle-icon-theme-git

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -536,6 +536,7 @@ python-qiskit-aer # (python-qiskit)
 python-qiskit
 
 # Issue 584
+flashrom-git  # (dep vboot-utils)
 geekbench
 hfsprogs
 megatools
@@ -585,7 +586,7 @@ tfsec
 minecraft-technic-launcher
 
 # Issue 649
-gitify
+gitify-bin
 
 # Issue 651
 redshift-minimal
@@ -1035,9 +1036,6 @@ act
 
 # Issue 930
 surfn-icons-git
-
-# Issue 932
-lariza
 
 # Issue 934
 gnome-obfuscate


### PR DESCRIPTION
Continuing #2358...

* gitify # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/gitify.log), [aur](https://aur.archlinux.org/pkgbase/gitify), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+gitify) – switch to gitify-bin
* kvantum-theme-layan-git # [aur](https://aur.archlinux.org/pkgbase/kvantum-theme-layan-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+kvantum) – pkgbase: layan-kde-git
* lariza # [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+layan-kde) – removed from aur, development discontinued
* layan-kde-git # [aur](https://aur.archlinux.org/pkgbase/layan-kde-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+layan-kde) – pkgbase: layan-kde-git
* vboot-utils # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/vboot-utils.log), [aur](https://aur.archlinux.org/pkgbase/vboot-utils), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+vboot-utils) – add dependency flashrom-git

Affected issues: #932
