### PR TITLE
Drop python311

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -880,9 +880,6 @@ prismlauncher-qt5-git
 # Issue 2045
 ipfs-desktop
 
-# Issue 2046
-python311
-
 # Issue 2053
 libretro-mupen64plus-next-git
 


### PR DESCRIPTION
`core/python` has been upgraded to 3.11.3.

Related #2046