### PR TITLE
Fix and drop packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -403,12 +403,6 @@ youtube-search-python # (dep ytmdl)
 python-simber # (dep ytmdl)
 ytmdl
 
-# Issue 1599
-blackbox-terminal-git
-libadwaita-git # (dep blackbox-terminal-git)
-libmarble-git # (dep blackbox-terminal-git)
-vte4-git
-
 # Issue 1606
 whatsie-git
 
@@ -822,9 +816,6 @@ cobang
 # Issue 1979
 decoder
 
-# Issue 1982
-kasts
-
 # Issue 1983
 corrosion-git # (dep pikasso-git)
 pikasso-git
@@ -915,6 +906,9 @@ icon-library
 
 # Issue 2113
 dendrite
+
+# Issue 2116
+blackbox-terminal
 
 # Issue 2118
 rsync-reflink

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -90,7 +90,6 @@ wlogout
 gestures
 gtkhash
 mugshot
-python-pyparted # (dep mugshot)
 
 
 ## Further needed applications

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -945,9 +945,6 @@ libva-intel-driver-g45-h264
 libcmrt # (dep intel-hybrid-codec-driver)
 intel-hybrid-codec-driver
 
-# Issue 1423
-limine
-
 # Issue 1435
 apple-fonts
 
@@ -1075,9 +1072,6 @@ session-desktop-bin
 
 # Issue 1556
 lazydocker
-
-# Issue 1557
-navi
 
 # Issue 1558
 crazydiskinfo
@@ -1637,7 +1631,6 @@ mesa-tkg-git:https://github.com/Frogging-Family/mesa-git.git
 ## Lost & found
 anaconda
 fluent-reader
-fnott
 java-openjdk-ea-bin
 telegram-desktop-bin-dev
 ytfzf-git

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -237,7 +237,7 @@ python39
 antimicrox
 cemu
 citra-canary-git
-citra-qt-git
+citra-git:https://aur.archlinux.org/citra-git.git # citra-git citra-qt-git
 conan # (dep yuzu-mainline-git)
 crossover
 duckstation-git
@@ -538,14 +538,10 @@ python-qiskit
 flashrom-git  # (dep vboot-utils)
 geekbench
 hfsprogs
-megatools
 phoronix-test-suite
 radeon-profile-git
 trousers # (dep vboot-utils)
 vboot-utils
-
-# Issue 588
-alacritty-ligatures-git
 
 # Issue 624
 gnome-network-displays


### PR DESCRIPTION
More changes to address #2358.

* alacritty-ligatures-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/alacritty-ligatures-git.log), [aur](https://aur.archlinux.org/pkgbase/alacritty-ligatures-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+alacritty-ligatures-git) – alacritty-ligatures fork is unmaintained
* blackbox-terminal-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/blackbox-terminal-git.log), [aur](https://aur.archlinux.org/pkgbase/blackbox-terminal-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+blackbox-terminal-git) – switch to blackbox-terminal
* citra-qt-git # [aur](https://aur.archlinux.org/pkgbase/citra-qt-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+citra) – pkgbase:citra-git – **please double check that syntax is correct**
* fnott # in community
* kasts # in extra
* limine # in community
* megatools # in community
* navi # in community
* python-pyparted # in community

Related issues: #588 #1423 #1557 #1599 #1982 #2116