### PR TITLE
Add fatrat-git

### DIFF
--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -1553,6 +1553,9 @@ libreoffice-dev-bin
 # Issue 2214
 lantern-bin
 
+# Issue 2215
+fatrat-git
+
 # Issue 2217
 wavesurfer
 
@@ -1573,6 +1576,9 @@ chatgpt-desktop-bin
 
 # Issue 2236
 floorp
+
+# Issue 2242
+soundcloud-nativefier
 
 # Issue 2251
 micromamba
@@ -1619,9 +1625,6 @@ ripcord
 
 # Issue 2413
 mullvad-browser-bin
-
-# Issue 2242
-soundcloud-nativefier
 
 # FroggingFamily
 mesa-tkg-git:https://github.com/Frogging-Family/mesa-git.git


### PR DESCRIPTION
Upstream issues have been fixed, and successfully builds in clean chroot on my machine.

Closes #2215.