### PR TITLE
Fix and drop broken packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -371,9 +371,6 @@ zecwallet-lite
 # Issue 1532
 shadowsocks-gtk-rs
 
-# Issue 1546
-salad-git
-
 # Issue 1549
 dwarfs-git
 dwarfs

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -97,7 +97,6 @@ mpv-full-git
 obs-backgroundremoval
 obs-rtspserver
 obs-streamfx
-obs-v4l2sink
 obs-vkcapture-git
 oneko
 pipewire-common-git
@@ -219,8 +218,7 @@ themix-plugin-base16-git
 themix-theme-arc-git
 themix-theme-materia-git
 themix-theme-oomox-git
-oomox-qt5-styleplugin-git
-oomox-qt6-styleplugin-git
+oomox-qt-styleplugin-git:https://aur.archlinux.org/oomox-qt-styleplugin-git.git # oomox-qt{5,6}-styleplugin-git
 
 # Programming (Solomon)
 clion-eap

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -114,7 +114,6 @@ nqp
 nteract-bin
 openxray
 popura-git
-powder-toy-git
 pup
 python-blis # (dep python-spacy)
 python-catalogue # (dep python-spacy)
@@ -943,11 +942,6 @@ targetcli-fb
 # Issue 878
 tblock
 
-# Issue 879
-cef-minimal # (dep obs-hevc-vaapi-git)
-obs-hevc-vaapi-git
-vlc-luajit # (dep obs-hevc-vaapi-git)
-
 # Issue 880
 wired
 
@@ -972,9 +966,6 @@ sardi-icons
 # Issue 894
 brisk-menu
 
-# Issue 895
-quassel-core-lighter-git
-
 # Issue 896
 libreddit-git
 
@@ -986,9 +977,6 @@ grub2-signing-extension
 
 # Issue 901
 losslesscut-bin
-
-# Issue 904
-obs-nvfbc
 
 # Issue 905
 shim-signed


### PR DESCRIPTION
Continuing #2358...

* powder-toy-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/powder-toy-git.log), [aur](https://aur.archlinux.org/pkgbase/powder-toy-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+powder-toy-git) – broken for 1.5 years; maintainer MIA
* quassel-core-lighter-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/quassel-core-lighter-git.log), [aur](https://aur.archlinux.org/pkgbase/quassel-core-lighter-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+quassel-core-lighter-git) – duplicate
* salad-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/salad-git.log), [aur](https://aur.archlinux.org/pkgbase/salad-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+salad-git) – requires private key to build?
* obs-nvfbc # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/obs-nvfbc.log), [aur](https://aur.archlinux.org/pkgbase/obs-nvfbc), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+obs-nvfbc) – does not support obs-studio > 27
* obs-v4l2sink # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/obs-v4l2sink.log), [aur](https://aur.archlinux.org/pkgbase/obs-v4l2sink), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+obs-v4l2sink) – functionality integrated into obs-studio
* obs-hevc-vaapi-git # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/obs-hevc-vaapi-git.log), [aur](https://aur.archlinux.org/pkgbase/obs-hevc-vaapi-git), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+obs-hevc-vaapi-git) – functionality integrated into obs-studio
* oomox-qt5-styleplugin-git # pkgbase: oomox-qt-styleplugin-git
* oomox-qt6-styleplugin-git # pkgbase: oomox-qt-styleplugin-git

Related issues #879 #895 #904 #1546