### PR TITLE
Drop broken packages

### DIFF
--- a/CatBuilder/hourly.txt
+++ b/CatBuilder/hourly.txt
@@ -1,7 +1,6 @@
 alvr
 android-studio-canary
 epson-inkjet-printer-escpr2
-gajim-git
 google-chrome-beta
 hotspot
 kddockwidgets # (dep hotspot)

--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -332,9 +332,6 @@ nerd-fonts-jetbrains-mono
 nvidia-open-beta
 nvidia-open-git
 
-# Issue 1432
-elementary-planner
-
 # Issue 1438
 deluge-git
 

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -108,7 +108,6 @@ slack-electron
 spirv-cross # (mpv-full-git dependency)
 spotify-qt
 swayfire-git
-steinberg-asio-sdk # (wineasio-git dependency)
 subtitleedit
 tor-browser
 ttf-borg-sans-mono

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -852,7 +852,6 @@ dino-git
 
 # Issue 806
 gajim-plugin-omemo
-gajim-plugin-omemo-git
 
 # Issue 807
 libtd
@@ -1663,21 +1662,6 @@ canta-kde-git
 contrast
 
 # Issue 1749
-python-dephell-specifier # (dep python-dephell curlew)
-python-dephell-pythons # (dep python-dephell curlew)
-python-dephell-archive # (dep python-dephell curlew)
-python-dephell-argparse # (dep python-dephell curlew)
-python-dephell-changelogs # (dep python-dephell curlew)
-python-dephell-discover # (dep python-dephell curlew)
-python-dephell-licenses # (dep python-dephell curlew)
-python-dephell-links # (dep python-dephell curlew)
-python-dephell-markers # (dep python-dephell curlew)
-python-dephell-setuptools # (dep python-dephell curlew)
-python-dephell-shells # (dep python-dephell curlew)
-python-dephell-venvs # (dep python-dephell curlew)
-python-dephell-versioning # (dep python-dephell curlew)
-python-m2r # (dep python-dephell curlew)
-python-dephell # (dep python-xdg curlew)
 python-xdg # (dep curlew)
 curlew
 


### PR DESCRIPTION
Continuing #2358...

* elementary-planner # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/elementary-planner.log), [aur](https://aur.archlinux.org/pkgbase/elementary-planner), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+elementary-planner) – missing depends, maintainer has no intention to fix, upstream project will be renamed soon
* gajim-git – duplicate entry
* gajim-plugin-omemo-git – functionality merged into gajim-git
* python-dephell-* # – no longer needed, aur unmaintained
* python-m2r # – no longer needed
* steinberg-asio-sdk # [log](https://builds.garudalinux.org/repos/chaotic-aur/logs/steinberg-asio-sdk.log), [aur](https://aur.archlinux.org/pkgbase/steinberg-asio-sdk), [search](https://github.com/chaotic-aur/packages/issues?q=is:issue+steinberg-asio-sdk) – unneeded dependency

Related #1432