### PR TITLE
 Drop and fix broken packages

### DIFF
--- a/dragon-cluster/afternoon.txt
+++ b/dragon-cluster/afternoon.txt
@@ -21,7 +21,7 @@ linux-amd-znver3
 linux-next-git
 
 # Issue 698
-yuzu-git:https://gitlab.com/tallero/yuzu-git-aur.git
+yuzu-git
 
 # Issue 816 / 1361
 firefox-appmenu

--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -496,8 +496,6 @@ libcprime # (dep corepdf corekeyboard coreimage corepad corepaint)
 corekeyboard
 corepdf
 metronome
-lua-event # (dep metronome-git)
-metronome-git
 health
 image-roll-bin
 g4music

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -24,7 +24,7 @@ digital
 netlistsvg-git
 tzsp2pcap-git
 guile1.8 # (dep texmacs)
-gr-limesdr-git:https://github.com/chaotic-aur/pkgbuild-gr-limesdr-git.git
+gr-limesdr-git
 gr-foo-git
 gr-ieee802-11-git
 hal-git
@@ -372,9 +372,6 @@ xxd-standalone
 
 # Issue 337
 eclipse-java
-
-# Issue 336
-giara
 
 # Issue 335
 compiz
@@ -726,11 +723,6 @@ bluej
 libvterm-0.1 # (dep neovim-git)
 neovim-git
 
-# Issue 504
-blueprint-compiler-git # (dep gfeeds-git)
-gfeeds-git
-python-syndom-git # (dep gfeeds-git)
-
 # Issue 508
 llvm-proton-bin
 
@@ -759,9 +751,6 @@ spot-client-git
 mint-themes
 mint-x-icons
 mint-y-icons
-
-# Issue 591
-sushi-git
 
 # Issue 592
 biglybt


### PR DESCRIPTION
More chaotic-aur/packages#2358...

* blueprint-compiler-git # check failures, use `community/blueprint-compiler` instead
* gfeeds-git # broken build/dependencies; use `community/gfeeds` instead
* giara # broken build/dependencies
* gr-limesdr-git # switch to AUR
* metronome-git # poor maintainership; misc packaging issues; broken build
* sushi-git # poor maintainership; use `extra/sushi` instead
* yuzu-git # switch to AUR

Related chaotic-aur/packages#336 chaotic-aur/packages#504 chaotic-aur/graveyard#688 chaotic-aur/packages#1693