### PR TITLE
Drop and fix broken packages

### DIFF
--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -38,12 +38,9 @@ linux-wifi-hotspot
 webapp-manager
 
 # Mycroft
-fann
-mimic1
 mycroft-core
 mycroft-gui-git
 plasma5-applets-mycroft-git
-python-xdgenvpy
 
 # Librewolf
 librewolf-extension-bitwarden

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -107,7 +107,6 @@ repoctl
 slack-electron
 spirv-cross # (mpv-full-git dependency)
 spotify-qt
-swayfire-git
 subtitleedit
 tor-browser
 ttf-borg-sans-mono

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -207,7 +207,7 @@ vim-coc-pyright-git
 vim-coc-rust-analyzer-git
 vim-coc-sh-git
 vim-coc-snippets-git
-vim-coc-sources-git # (vim-coc-{dictionary,emoji,syntax,tag,word}-git)
+vim-coc-sources-git:https://aur.archlinux.org/vim-coc-sources-git.git # (vim-coc-{dictionary,emoji,syntax,tag,word}-git)
 vim-coc-tabnine-git
 vim-coc-tsserver-git
 vim-coc-vetur-git
@@ -992,9 +992,6 @@ superslicer-profiles-git
 
 # Issue 910
 keepassxc-git
-
-# Issue 912
-git-bug-git
 
 # Issue 913
 vimiv-qt


### PR DESCRIPTION
More for #2358...

* fann # unnecessary depends
* git-bug-git # poor maintainership; use `community/git-bug`
* mimic1 # unnecessary depends
* python-xdgenvpy # unnecessary depends
* swayfire-git # poor maintainership; broken build
* vim-coc-sources-git # fix pkgbase

Related #912