### PR TITLE
Drop and fix broken packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -162,7 +162,6 @@ valent-git
 gtkcord4
 
 # gaelic on forum
-python-wxpython-dev # (dep grass)
 grass
 
 # oldrocker99 on forum

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -38,6 +38,8 @@ linux-wifi-hotspot
 webapp-manager
 
 # Mycroft
+fann # (dep mycroft-core)
+mimic1 # (dep mycroft-core)
 mycroft-core
 mycroft-gui-git
 plasma5-applets-mycroft-git

--- a/ufscar-hpc/daily.1.txt
+++ b/ufscar-hpc/daily.1.txt
@@ -91,7 +91,7 @@ swiftshader-git
 swift-language-git:https://github.com/chaotic-aur/pkgbuild-swift-language-git
 
 # Issue 1632
-kodi-git
+kodi-git:https://aur.archlinux.org/kodi-git.git
 
 # Issue 2175
 kodi-nexus-git

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -808,13 +808,6 @@ touchegg
 # Issue 613
 papirus-folders
 
-# Issue 614
-kquickchatcomponents-git # (dep tok-git)
-libtd-git # (dep tok-git)
-qbs-git # (dep tok-git)
-rlottie-git # (dep tok-git)
-tok-git
-
 # Issue 615
 silo-trello
 trello

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -608,9 +608,6 @@ logmein-hamachi # (dep haguichi)
 # Issue 675
 lmms-git
 
-# Issue 678
-mpv-vapoursynth-git
-
 # Issue 680
 mips64-elf-binutils
 
@@ -716,8 +713,8 @@ basilisk-bin
 rider
 
 # Issue 741
-apparmor-git
 celluloid-git
+mpv-vapoursynth-git
 
 # Issue 743
 qtile-git


### PR DESCRIPTION
More #2358...

* apparmor-git # use `extra/apparmor` instead
* fann, mimic1 # needed for mycroft-core
* kodi-git # pkgbase
* python-wxpython-dev # unnecessary dependency
* tok-git # abandoned project

Related #614 #678 #741