### PR TITLE
Drop and fix broken packages

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -836,10 +836,10 @@ libumem-git # (dep imagemagick-full-git)
 imagemagick-full-git
 
 # Issue 2029
+libopenglrecorder # (dep supertuxkart-git)
+mindustry-git
 openttd-git
 simutrans-extended-git
-mindustry-git
-libopenglrecorder # (dep supertuxkart-git)
 supertuxkart-git
 
 # Issue 2036

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -468,9 +468,6 @@ ttf-mac-fonts
 ttf-ms-fonts
 rocketchat-desktop
 
-# Issue 372
-zestginx
-
 # Issue 345
 systemd-cron-next-git
 
@@ -858,8 +855,12 @@ dbus-x11
 gnome-shell-extension-dash-to-panel-git
 
 # Issue 1336
+cask-server-git # (dep maui-shell-git)
+maui-core-git # (dep maui-shell-git)
 maui-shell-git
+mauikit-calendar-git # (dep maui-shell-git)
 mauikit-git
+mauiman-git # (dep maui-shell-git)
 
 # Issue 1339
 dee # (dep libunity webwatcher-git)

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -166,7 +166,6 @@ libayatana-common # (dep ayatana-*)
 libclc-git # (dep mesa-git)
 libselinux # (dep glib2-selinux)
 libsepol # (dep glib2-selinux)
-lightdm-pantheon-greeter-git
 
 egl-wayland-git
 lib32-libdrm-git
@@ -295,7 +294,6 @@ python-injector # (dep gwe)
 q4wine-git
 qt-solutions-git # (dep q4wine-git)
 rare-git
-replay-sorcery
 reshade-shaders-git
 retroarch-autoconfig-udev-git
 retrolink-git
@@ -500,9 +498,6 @@ neovide-git
 # Issue 566
 mediainfo-gui-qt
 
-# Issue 567
-telephant-git
-
 # Issue 571
 authy
 f2c # (dep meshlab)
@@ -618,7 +613,6 @@ python-protonvpn-nm-lib # (dep protonvpn-gui)
 
 # Issue 684
 openboard
-openboard-git
 
 # Issue 686
 youtube-music-bin


### PR DESCRIPTION
More #2358...

* lightdm-pantheon-greeter-git # broken; poor maintainership; use `community/lightdm-pantheon-greeter` instead
* maui-shell-git # add depends
* openboard-git # broken; poor maintainership; use `openboard` instead
* replay-sorcery # broken; poor maintainership; use `replay-sorcery-git` instead
* telephant-git # broken; poor maintainership
* zestginx # broken since inception over two years ago (poor maintainership)

Related #372 #567