### PR TITLE
drop ly, rapidyaml-git

### DIFF
--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -461,7 +461,6 @@ oh-my-zsh-git
 omnisharp-roslyn
 
 # Issue 371
-ly
 multimc5
 spotify-tui
 ttf-mac-fonts

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -1044,9 +1044,6 @@ autokey:https://aur.archlinux.org/autokey.git # (autokey-common autokey-gtk auto
 # Issue 960
 anki
 
-# Issue 964
-rapidyaml-git # (dep pcsx2-git, also creates python-rapidyaml-git)
-
 # Issue 966
 qimgv-git
 


### PR DESCRIPTION
* `ly` # upgraded to `community`
* `rapidyaml-git` # no longer needed dependency

Note: `pcsx2-git` was previously moved to garuda-cluster.  Now builds and runs fine with `community/rapidyaml`.