### PR TITLE
Drop packages that have been removed from AUR

### DIFF
--- a/dragon-cluster/_kde_apps.txt
+++ b/dragon-cluster/_kde_apps.txt
@@ -114,7 +114,6 @@ plasma5-applets-latte-separator
 plasma5-applets-latte-sidebar-button
 plasma5-applets-latte-spacer
 plasma5-applets-window-appmenu-git
-plasma5-applets-window-buttons-git
 plasma5-applets-window-title-git
 polkit-qt5-git
 poppler-git

--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -78,7 +78,6 @@ waybar-hyprland-git
 waydroid-git
 whoogle
 whoogle-git
-wlroots-eglstreams-git
 woeusb-ng
 xdg-ninja-git
 xorg-server-git:https://aur.archlinux.org/xorg-server-git.git
@@ -322,9 +321,6 @@ mypy-git
 
 # Issue 1421
 wxformbuilder
-
-# Issue 1424
-nerd-fonts-jetbrains-mono
 
 # Issue 1428
 nvidia-open-beta

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -138,7 +138,6 @@ autotiling
 candy-icons-git
 catppuccin-gtk-theme-mocha
 catppuccin-mocha-grub-theme-git
-catppuccin-wallpapers-git
 flat-remix
 flat-remix-gtk
 fluent-gtk-theme-git

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -103,7 +103,6 @@ mugshot
 ananicy-cpp
 ananicy-rules-git # (dep ananicy-cpp)
 apprise
-archlinux-appstream-data-pamac
 auto-cpufreq
 bluetooth-autoconnect
 btrfs-assistant

--- a/garuda-cluster/nightly.txt
+++ b/garuda-cluster/nightly.txt
@@ -1,7 +1,6 @@
 # Dr460nized
 firedragon
 thunderbird-appmenu
-kfiredragonhelper
 
 
 ## Chaotic
@@ -16,9 +15,6 @@ emacs-git
 
 # Issue 726
 godot-mono  # non parallelizable
-
-# Issue 1042
-linux-xanmod-tt
 
 
 ## Not building for whatever reason, lets try it here

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -213,7 +213,6 @@ themix-icons-suru-plus-aspromauros-git
 themix-icons-suru-plus-git
 themix-import-images-git
 themix-plugin-base16-git
-themix-theme-arc-git
 themix-theme-materia-git
 themix-theme-oomox-git
 oomox-qt-styleplugin-git:https://aur.archlinux.org/oomox-qt-styleplugin-git.git # (oomox-qt{5,6}-styleplugin-git)

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -376,7 +376,6 @@ openbangla-keyboard # Issue 321
 wine-x64 # Issue 330
 winbox64 # Issue 330
 wine-stable # Issue 311
-gdm-plymouth # Issue 401
 
 ## Not building on ufscar
 # Issue 322
@@ -1134,9 +1133,6 @@ firefly-iii
 # Issue 1013
 stacer-git
 
-# Issue 1015
-opendoas-sudo
-
 # Issue 1017
 armorpaint-git
 
@@ -1263,9 +1259,6 @@ graphite-cursor-theme-git
 # Issue 1098
 rpi-imager
 
-# Issue 1100
-papirus-folders-gui
-
 # Issue 1101
 sayonara-player-git
 
@@ -1314,9 +1307,6 @@ jamesdsp-pulse
 
 # Issue 1143
 biglybt-extreme-mod
-
-# Issue 1144
-adwmod-theme-git
 
 # Issue 1146
 emulsion
@@ -1530,9 +1520,6 @@ plasma5-applets-virtual-desktop-bar-git
 # Issue 1571
 zramswap
 
-# Issue 1572
-nsxiv
-
 # Issue 1573
 ff2mpv-native-messaging-host-git
 
@@ -1570,9 +1557,6 @@ flatseal
 
 # Issue 1624
 datagrip
-
-# Issue 1629
-powerdevil-ddcutil
 
 # Issue 1639
 libmodule # (dep clightd)


### PR DESCRIPTION
These packages have all been dropped from the AUR.  The PRQ may be found at [aur-requests](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/).

* adwmod-theme-git
* archlinux-appstream-data-pamac # Garuda base
* catppuccin-wallpapers-git # ???
* gdm-plymouth # functionality now in `extra/gdm`
* kfiredragonhelper # Dr460nized
* linux-xanmod-tt # `linux-xanmod` is already chaotic
* nerd-fonts-jetbrains-mono # `community/ttf-jetbrains-mono-nerd`
* nsxiv # `community/nsxiv`
* opendoas-sudo
* papirus-folders-gui
* plasma5-applets-window-buttons-git # dr460nf1r3
* powerdevil-ddcutil # `extra/ddcutil`
* themix-theme-arc-git # Solomon
* wlroots-eglstreams-git # `wlroots-git` already in chaotic

See #2358

Related issues: #401 #1015 #1042 #1100 #1144 #1424 #1572 #1629
