### PR TITLE
Replace packages that have been removed from AUR.

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -855,8 +855,8 @@ ipfs-desktop
 # Issue 2053
 libretro-mupen64plus-next-git
 
-# Issue 2054
-mesen-x-git
+# Issue 2054, 2080
+mesen2-git
 
 # Issue 2064
 qbittorrent-git
@@ -864,9 +864,6 @@ qbittorrent-git
 # Issue 2079
 zfs-utils-git
 zfs-dkms-git
-
-# Issue 2080
-mesen-sx-git
 
 # Issue 2085
 prboom-plus
@@ -954,9 +951,9 @@ scid
 dragon-drop-git
 
 # Issue 2172
-woof-doom
 dsda-doom
-woof-git
+woof-doom
+woof-doom-git
 
 # Issue 2174
 shattered-pixel-dungeon-git

--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -66,7 +66,7 @@ dropbox
 fonts-tlwg
 foxitreader
 google-earth-pro
-google-meet-desktop
+google-meet-nativefier
 gstreamer0.10 # (dep foxitreader)
 gstreamer0.10-base # (dep foxitreader)
 guiscrcpy

--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -120,7 +120,7 @@ find-the-command-git
 firefox-extension-bitwarden
 firefox-extension-flagfox
 firefox-extension-localcdn
-firefox-extension-plasma-integration
+firefox-extension-plasma-integration-bin
 fish-autopair
 flameshot-git
 garuda-downloader-git
@@ -171,12 +171,12 @@ zsync2-git
 8188eu-aircrack-dkms-git
 8188fu-dkms-git
 8188fu-kelebek333-dkms-git
-8192eu-dkms
+8192eu-dkms-git
 r8168-dkms
 realtek-firmware
 rtl8192cu-fixes-git
 rtl88x2bu-dkms-git
-rtl88x2ce-dkms
+rtl88x2ce-dkms-git
 rtl88xxau-aircrack-dkms-git
 rtw88-dkms-git
 rtw89-dkms-git

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -681,7 +681,7 @@ python-bibtexparser # (dep setzer-git)
 setzer-git
 
 # Issue 484
-multimc-curseforge
+launcher-curseforge-bin
 
 # Issue 485
 pipe-viewer-git
@@ -728,7 +728,7 @@ godot-git:https://github.com/chaotic-aur/pkgbuild-godot-git.git
 ryujinx-git
 
 # Issue 579
-youtube-bin
+youtube
 
 # Issue 585
 exifcleaner-bin

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -42,7 +42,7 @@ ffmpeg-full
 figma-linux
 foo2zjs-nightly
 glew-egl-glx
-google-cloud-sdk
+google-cloud-cli
 heroku-cli-bin
 hunspell-pt-br
 intelbacklight-git
@@ -1461,9 +1461,6 @@ velox-git
 
 # Issue 1456
 python-chess-git # (dep stockfish-git)
-mongosh-bin # (dep mongodb-bin)
-mongodb-bin # (dep polyglot)
-polyglot # (dep stockfish-git)
 stockfish-git
 
 # Issue 1481
@@ -1924,7 +1921,7 @@ ucon64
 asus-n551-hda-fix
 
 # Issue 2307
-polyglot-winboard-git # (dep fairy-stockfish{-git})
+polyglot-winboard-git # (optdep fairy-stockfish fairy-stockfish-git stockfish-git)
 fairy-stockfish
 fairy-stockfish-git
 


### PR DESCRIPTION
These packages have all been dropped from the AUR.  The PRQs may be found at [aur-requests](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/).

* 8192eu-dkms # switch to `8192eu-dkms-git`
* firefox-extension-plasma-integration # switch to `firefox-extension-plasma-integration-bin`
* google-cloud-sdk # switch to `google-cloud-cli`
* google-meet-desktop # switch to `google-meet-nativefier`
* mesen-x-git, mesen-sx-git # switch to `mesen2-git`
* multimc-curseforge # switch to `launcher-curseforge-bin`
* polyglot # switch to `polyglot-winboard-git` (see notes)
* rtl88x2ce-dkms # switch to `rtl88x2ce-dkms-git`
* youtube-bin # switch to `youtube`
* woof-git # switch to `woof-doom-git`

Notes:
* Alternate packages have already been built.
* polyglot was the wrong package, not chess related.  Also dropping dependencies: mongosh-bin, mongodb-bin


See #2358
Related: #2054 #2080 #484 #579 #1456 #2307