### PR TITLE
drop fprintd-libfprint2

### DIFF
--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -16,7 +16,6 @@ android-studio
 chromium-widevine
 digilent.adept.runtime
 digilent.adept.utilities
-fprintd-libfprint2:https://aur.archlinux.org/fprintd-libfprint2.git
 fujprog
 fxload
 xschem


### PR DESCRIPTION
Dropped from AUR.  [PRQ#40173](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/Y4XQLWKHVBNFUGMOTM6MLJJWRFA5DCPP/#Y4XQLWKHVBNFUGMOTM6MLJJWRFA5DCPP)

This is in a "Paulo" section.