### PR TITLE
drop mangohud, gajim-plugin-omemo, python-sentry_sdk

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -408,7 +408,6 @@ orchis-theme-git
 
 # Issue 1623
 python-readchar # (dep moodle-dl-git)
-python-sentry_sdk # (dep moodle-dl-git)
 python-xmpppy-git # (dep moodle-dl-git)
 moodle-dl-git
 

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -838,9 +838,6 @@ nvim-ghost-git
 # Issue 805
 dino-git
 
-# Issue 806
-gajim-plugin-omemo
-
 # Issue 807
 libtd
 

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -79,7 +79,6 @@ faudio-tkg-git:https://github.com/Frogging-Family/faudio-git.git
 gallium-nine-git
 gamescope-git:https://github.com/Frogging-Family/gamescope-git.git
 goverlay-git
-mangohud:https://aur.archlinux.org/mangohud.git # (dep lutris-wine-git)
 mangohud-git
 material-kwin-decoration-git:https://aur.archlinux.org/material-kwin-decoration-git.git
 neofrog-git:https://github.com/Frogging-Family/neofrog-git.git
@@ -1569,7 +1568,6 @@ uutils-coreutils-git
 
 # Issue 1666
 xkb-switch
-lib32-mangohud
 libstrangle-git
 latencyflex-git
 lutris-wine-git


### PR DESCRIPTION
These packages have been dropped from the AUR.  The PRQs may be found at [aur-requests](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/).

* mangohud # in extra
* lib32-mangohud # in multilib
* gajim-plugin-omemo # functionality integrated into `extra/gajim`
* python-sentry_sdk # in extra

Note: `mangohud-git` and `lib32-mangohud-git` are still in chaotic.