### PR TITLE
zenmap-python3-git → zenmap-git

### DIFF
--- a/dragon-cluster/hourly.txt
+++ b/dragon-cluster/hourly.txt
@@ -986,8 +986,8 @@ snapper-support:https://gitlab.com/garuda-linux/packages/stable-pkgbuilds/snappe
 
 # Issue 2243
 libgksu # (dep gksu)
-gksu # (dep zenmap-python3-git)
-zenmap-python3-git
+gksu # (optdep zenmap-git)
+zenmap-git
 
 # Issue 2259
 hyprland-nvidia


### PR DESCRIPTION
`zenmap-python3-git` has some issues that are fixed in `zenmap-git`:

* Broken `pkgver` prevents rebuild, making it a duplicate of `zenmap`.
* Refers to nonexistent `/usr/lib/python3.10`
* Doesn't install symlinks that `zenmap` does.
* Installs broken symlink

Related #2243