### PR TITLE
drop gnome-browser-connector, mint-themes-legacy, pnpm

### DIFF
--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -1099,9 +1099,6 @@ gnome-shell-pomodoro
 # Issue 1627
 libva-intel-driver-hybrid
 
-# Issue 1633
-gnome-browser-connector
-
 # Issue 1635
 tone-bin
 m4b-tool-bin

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -593,7 +593,6 @@ python-pychromecast # (dep photoqt)
 bluemail
 
 # Issue 668
-pnpm # (dep ledger-live ledger-udev)
 haguichi
 ledger-live
 ledger-udev # (dep ledger-live)
@@ -1274,9 +1273,6 @@ bulky
 pix
 sticky-git
 thingy
-
-# Issue 1116
-mint-themes-legacy
 
 # Issue 1118
 mcpelauncher-linux-git


### PR DESCRIPTION
These packages have been dropped from the AUR. The PRQs may be found at [aur-requests](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/).

* gnome-browser-connector # in extra
* mint-themes-legacy # superceded by another theme?
* pnpm # in extra

Related #1633 #1116