### PR TITLE
nvidia-vaapi-driver-git → libva-nvidia-driver-git

### DIFF
--- a/CatBuilder/hourly.txt
+++ b/CatBuilder/hourly.txt
@@ -15,5 +15,5 @@ python-nbxmpp-git
 python-omemo-dr-git
 tidal-hifi-bin
 tor-router
-nvidia-vaapi-driver-git
+libva-nvidia-driver-git
 wowup-cf-bin


### PR DESCRIPTION
[PRQ#40508](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/Q3JRHAZWNJFOTJI43G2COGECU3NZKZAY/#XQSW33EQTE5S63NI7WT7LFGJO36N2AZ6)