### PR TITLE
Ban packages that are specific to non-Arch distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This is a list of packages that we will reject for good reasons:
 
 - **linux-ck**: Two reasons, first our `linux-tkg-*` already includes those bits of optimizations, second there is [repo-ck](https://wiki.archlinux.org/title/Unofficial_user_repositories#repo-ck) with official pre-built binaries for it.
 
+- Packages that are specific to non-Arch distributions, like deb or rpm package managers.  Use `distrobox` with `podman` or `docker`.
+
 #### Banned due to licensing issues 🛑
 
 - **aseprite{-git}**: Redistribution is explicitly prohibited in its [FAQ](https://www.aseprite.org/faq/#can-i-redistribute-aseprite).

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ This is a list of packages that we will reject for good reasons:
 
 - **aseprite{-git}**: Redistribution is explicitly prohibited in its [FAQ](https://www.aseprite.org/faq/#can-i-redistribute-aseprite).
 
-- **multimc-git**: Redistribution of custom binaries that include their API keys and trademarked assets is [explicitly prohibited](https://multimc.org/#Branding).
-
-- **tlauncher**: Legal gray area, as it potentially allows playing Minecraft in a reduced capacity without license.
-
 - **feishu**: Unauthorized redistribution of their applications is explicitly prohibited per [ToS](https://www.feishu.cn/en/terms).
 
+- **multimc-git**: Redistribution of custom binaries that include their API keys and trademarked assets is [explicitly prohibited](https://multimc.org/#Branding).
+
 - **rider**: Redistribution disallowed per [ToS](https://www.jetbrains.com/legal/docs/toolbox/user).
+
+- **tlauncher**: Legal gray area, as it potentially allows playing Minecraft in a reduced capacity without license.


### PR DESCRIPTION
Propose to ban packages that are specific to non-arch distros, like package managers.  Recommend to use `distrobox` with `podman` or `docker`.

As far as I know, no packages in chaotic are currently affected.  This is mainly to prevent requests for poorly maintained/broken packages whose original packagers and maintainers no longer actually use them because they moved on to other solutions or distros.

Pros/cons discussion?  Other alternative recommendations?  Objections?