### PR TITLE
Drop todoist-electron

### DIFF
--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -278,7 +278,6 @@ python-moviepy # (dep tartube)
 python-playsound # (dep tartube)
 python-pgi # (dep tartube)
 tartube
-todoist-electron
 todoist-nativefier
 tuc
 upscayl-bin


### PR DESCRIPTION
Dropped from AUR.  [PRQ#42294](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/BB3IZL566AHBACTVEHTVYJTE46IKF7YR/#GXYGXUXZVKBD7EBWXCNH7TFBDVNZY6WU).

@Technetium1 Package was in your section.