### PR TITLE
Drop qutebrowser-qt6-git

### DIFF
--- a/garuda-cluster/nightly.txt
+++ b/garuda-cluster/nightly.txt
@@ -106,7 +106,6 @@ tradingview # The best trades require research, then commitment. ; https://www.t
 motivewave # A Trading Platform to Fit Any Trader or Market Analyst ; https://www.motivewave.com/
 rebar3 # A sophisticated build-tool for Erlang projects that follows OTP principles. ; https://github.com/erlang/rebar3
 elixir-ls # A frontend-independent Language Server Protocol for Elixir ; https://github.com/elixir-lsp/elixir-ls
-qutebrowser-qt6-git # A keyboard-driven, vim-like browser based on Python and Qt. ; https://github.com/qutebrowser/qutebrowser
 roundedsbe-git:https://github.com/chaotic-aur/pkgbuild-roundedsbe-git.git # A fork of SierraBreezeEnhanced with integrated corner rounding effect CornersShader (reworked version of what used to be called LightlyShaders) and shared configuration ; https://github.com/a-parhom/RoundedSBE
 
 

--- a/kde-git/nightly.txt
+++ b/kde-git/nightly.txt
@@ -255,7 +255,6 @@ poppler-git
 qca-qt5-git
 qca-qt6-git
 qtkeychain-qt5-git:https://github.com/chaotic-aur/pkgbuild-qtkeychain-qt5-git.git
-qutebrowser-qt6-git # try to use the aur package, since its mantained by the dev :https://github.com/chaotic-aur/pkgbuild-qutebrowser-qt6-git.git
 sddm-config-editor-git  # Issue 453
 sddm-git
 sddm-theme-astronaut  # Issue 1168


### PR DESCRIPTION
[PRQ#45240](https://lists.archlinux.org/archives/list/aur-requests@lists.archlinux.org/thread/MYZMFHZIRVX6G4MMTJM5YBBKKOHJ7VKC/#MYZMFHZIRVX6G4MMTJM5YBBKKOHJ7VKC) - merged into `qutebrowser-git`, which is already in chaotic:

https://github.com/chaotic-aur/packages/blob/b468ad61b8dc1c9dbd30c83c5043e7472d59865b/ufscar-hpc/hourly.1.txt#L228-L229