### PR TITLE
Move qutebrowser-git from ufscar-hpc to garuda-cluster

### DIFF
--- a/garuda-cluster/hourly.1.txt
+++ b/garuda-cluster/hourly.1.txt
@@ -208,6 +208,7 @@ schildichat-desktop
 # Alexjp
 bcache-tools
 libgaminggear # (dep roccat-tools)
+qutebrowser-git
 roccat-tools:https://aur.archlinux.org/roccat-tools.git # (Also includes roccat-tools-common,roccat-tools-{isku,iskufx,kiro,kone,koneplus,konepure,konepuremilitary,konepureoptical,konextd,konextdoptical,kova2016,kovaplus,pyra,ryostkl,savu,skeltr,sova,suora}
 
 

--- a/ufscar-hpc/hourly.1.txt
+++ b/ufscar-hpc/hourly.1.txt
@@ -228,9 +228,6 @@ helix-git
 ttf-iosevka-git
 ttfautohint
 
-# Web browsers (Solomon)
-qutebrowser-git
-
 
 ## Technetium1
 arp-scan-git


### PR DESCRIPTION
Moving `qutebrowser-git` from ufscar-hpc (section marked Solomon) to garuda-cluster (section marked @alexjp).

Solomon = @SolarAquarion ?

 See #2741