### PR TITLE
Move yuzu-mainline-git, et al from ufscar-hpc to garuda-cluster

### DIFF
--- a/garuda-cluster/hourly.2.txt
+++ b/garuda-cluster/hourly.2.txt
@@ -181,6 +181,13 @@ wd719x-firmware
 
 
 ## Chaotic
+# Issue 340
+conan # (dep yuzu-mainline-git)
+python-node-semver # (dep conan)
+python-patch-ng # (dep conan)
+python-pluginbase # (dep conan)
+yuzu-mainline-git
+
 # Issue 377
 edid-decode-git
 

--- a/ufscar-hpc/hourly.2.txt
+++ b/ufscar-hpc/hourly.2.txt
@@ -237,7 +237,6 @@ antimicrox
 cemu
 citra-canary-git
 citra-git:https://aur.archlinux.org/citra-git.git # (citra-git citra-qt-git)
-conan # (dep yuzu-mainline-git)
 cpp-httplib-compiled # (dep xemu-git)
 crossover
 duckstation-git
@@ -251,14 +250,10 @@ mednaffe
 pcsxr
 pegasus-frontend-git
 play-emu-git
-python-node-semver # (dep conan)
-python-patch-ng # (dep conan)
-python-pluginbase # (dep conan)
 python-pysdl2 # (dep m64py tauon-music-box)
 sameboy
 ucl # (dep kega-fusion)
 xemu-git
-yuzu-mainline-git
 
 # Gaming
 athenaeum-git


### PR DESCRIPTION
[yuzu-mainline-git.log](https://builds.garudalinux.org/repos/chaotic-aur/logs/yuzu-mainline-git.log)

```
==> Retrieving sources...
  -> Updating yuzu git repo...
  -> Updating enet git repo...
  -> Updating inih git repo...
==> ERROR: /home/main-builder/pkgsrc/cubeb is not a clone of https://github.com/mozilla/cubeb.git
```

Related #2703