### PR TITLE
Describe package modifications in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,24 +15,25 @@ This is the right place to submit package requests, bug reports, or outdated pac
 
 #### Modified packages
 
-While we would prefer to build AUR packages without modification, this is often not practical or possible.
+While we would prefer to build AUR packages without modification, doing so is often not practical or possible.
 
-- Common errors and poor packaging practices are automatically corrected.
-    + Missing commands, or other adjustments, are added to allow the package to build successfully.
-    + Erroneous commands that could result in disruptive behaviors are removed.
-    + Automatic corrections are not marked because they usually do not alter package functionality.
-- Some packages are manually adjusted (interfere).
-    + Issues that the automatic corrections don't cover are corrected.
-    + Interfered packages are marked by an optional depends on `chaotic-interfere`.
-        -  `chaotic-interfere` is a dummy package that is *not* intended to be installed.  Installing it does no good or harm.
-- Some packages have been replaced by custom packages, usually a fork of the original.
-    + The original usually had some issue that was difficult to solve by other means.
-    + Fork vs interfere is decided case-by-case.
-        - Interfere capability may have been limited at the time of the fork.
-        - Some custom packages may be moved to the interfere system, or vice versa.
-    + Custom packages are *not* currently marked.
+- Depends, options, or commands may be missing.
+- Erroneous options or commands may be present.
+- Packages may not build or function without changes.
+- Packages may not meet packaging standards.
 
-Chaotic-AUR contains a metapackage, `chaotic-kf5-dummy`.  This is a *temporary* workaround to allow some packages to continue functioning while upstream renames the KF5 packages.  Eventually the dummy package, and any related packages that are not updated, will be dropped.  This is planned for when KF6 becomes the upstream default.
+To address such issues:
+
+- [Toolbox](https://github.com/chaotic-aur/toolbox) automatically corrects some common errors.
+- Manual corrections may be applied with [Interfere](https://github.com/chaotic-aur/interfere).
+- The original package may be forked as a custom package.
+
+#### Special packages
+
+- `chaotic-keyring`: Public keys to verify the Chaotic-AUR package signatures.
+- `chaotic-mirrorlist`: List of servers mirroring Chaotic-AUR packages.
+- `chaotic-interfere`: Marker indicating manually applied interferes.  This package is *not* intended to be installed.
+- `chaotic-kf5-dummy`: Workaround to allow packages with outdated KF5-related depends to continue to function.  Eventually this, and related packages that haven't been updated, will be dropped.  Planned for when KF6 becomes the upstream default.
 
 #### Banished and rejected packages 📑
 
@@ -60,7 +61,7 @@ This is a list of packages that we will reject for good reasons:
 
 - **aseprite{-git}**: Redistribution is explicitly prohibited in its [FAQ](https://www.aseprite.org/faq/#can-i-redistribute-aseprite).
 
-- **multimc-git**: Redistribution of custom binaries that include their API keys and trademarked assets is [explicitly prohibited](https://multimc.org/#Branding).
+- **multimc\***: Redistribution of custom binaries that include their API keys and trademarked assets is [explicitly prohibited](https://multimc.org/#Branding).
 
 - **tlauncher**: Legal gray area, as it potentially allows playing Minecraft in a reduced capacity without license.
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,35 @@ This is the right place to submit package requests, bug reports, or outdated pac
 
 ![Chaotic-AUR](https://avatars.githubusercontent.com/u/66071775?s=400&u=99bc0536e7e77fe3e58839996600848f2d930ed5&v=4)
 
-#### Examples of packages we have already built:
+#### Some packages we have already built
 
 - [Linux-tkg kernels](https://github.com/Frogging-Family/linux-tkg) (BMQ, CFS,LTO, PDS, TT + their generic_v3 variations)
 - Other popular kernel variations such as [Mainline](https://aur.archlinux.org/packages/linux-mainline)/, [Xanmod-{tt,rt,lts}](https://aur.archlinux.org/packages?O=0&SeB=nd&K=xanmod), [Vfio](https://aur.archlinux.org/packages/linux-vfio)/-[lts](https://aur.archlinux.org/packages/linux-vfio-lts), [Next-git](https://aur.archlinux.org/packages/linux-next-git), [Cachyos-BORE](https://aur.archlinux.org/packages/linux-cachyos-bore) or [TT](https://aur.archlinux.org/packages/linux-tt)
-- A quite complete [KDE stack build from master branch](https://invent.kde.org/explore/groups?sort=name_asc)
-- Most of the existing emulators & gaming utilities like [Yuzu](https://yuzu-emu.org/), [RPCS3](https://github.com/RPCS3/rpcs3) or {[Proton](https://github.com/GloriousEggroll/proton-ge-custom),[Wine](https://github.com/GloriousEggroll/wine-ge-custom)}-GE-Custom
-- A lot of browsers like [Firedragon](https://github.com/dr460nf1r3/firedragon-browser), [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium), [Firefox-wayland-hg](https://aur.archlinux.org/packages/firefox-wayland-hg), [Icecat](http://www.gnu.org/software/gnuzilla/) or the [Tor Browser](https://www.torproject.org/projects/torbrowser.html)
+- A quite complete [KDE stack](https://invent.kde.org/explore/groups?sort=name_asc) in a [separate repo](https://forum.garudalinux.org/t/kde-6-repository-testing/31442). 
+- Most of the existing emulators & gaming utilities like [Yuzu](https://yuzu-emu.org/), [RPCS3](https://github.com/RPCS3/rpcs3), and {[Proton](https://github.com/GloriousEggroll/proton-ge-custom),[Wine](https://github.com/GloriousEggroll/wine-ge-custom)}-GE-Custom
+- A lot of browsers like [Firedragon](https://github.com/dr460nf1r3/firedragon-browser), [Ungoogled Chromium](https://github.com/Eloston/ungoogled-chromium), [Firefox-wayland-hg](https://aur.archlinux.org/packages/firefox-wayland-hg), , and [Icecat](http://www.gnu.org/software/gnuzilla/)
 - ... a lot more. Check out the [package lists](https://github.com/chaotic-aur/packages/find/main) to find out what exactly gets built and when! 🕵️‍♀️
+
+#### Modified packages
+
+While we would prefer to build AUR packages without modification, this is often not practical or possible.
+
+- Common errors and poor packaging practices are automatically corrected.
+    + Missing commands, or other adjustments, are added to allow the package to build successfully.
+    + Erroneous commands that could result in disruptive behaviors are removed.
+    + Automatic corrections are not marked because they usually do not alter package functionality.
+- Some packages are manually adjusted (interfere).
+    + Issues that the automatic corrections don't cover are corrected.
+    + Interfered packages are marked by an optional depends on `chaotic-interfere`.
+        -  `chaotic-interfere` is a dummy package that is *not* intended to be installed.  Installing it does no good or harm.
+- Some packages have been replaced by custom packages, usually a fork of the original.
+    + The original usually had some issue that was difficult to solve by other means.
+    + Fork vs interfere is decided case-by-case.
+        - Interfere capability may have been limited at the time of the fork.
+        - Some custom packages may be moved to the interfere system, or vice versa.
+    + Custom packages are *not* currently marked.
+
+Chaotic-AUR contains a metapackage, `chaotic-kf5-dummy`.  This is a *temporary* workaround to allow some packages to continue functioning while upstream renames the KF5 packages.  Eventually the dummy package, and any related packages that are not updated, will be dropped.  This is planned for when KF6 becomes the upstream default.
 
 #### Banished and rejected packages 📑
 


### PR DESCRIPTION
Some changes to Readme:

* Minor updates to "packages we have already built", mainly adding link to the KDE-git repo.
* New section, Modified packages.  Chaotic AUR seems originally intended to build packages directly from AUR without modification.  However, doing so is not always practical or possible.  This section explains why and how modifications are made.
* New section, Special packages.  Describes packages specific to Chaotic-AUR, like `chaotic-keyring`, `chaotic-mirrorlist`, `chaotic-interfere`, and `chaotic-kf5-dummy`.
