### PR TITLE
Fix build mangohud-git and lib32-mangohud-git

### DIFF
--- a/lib32-mangohud-git/.SRCINFO
+++ b/lib32-mangohud-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = lib32-mangohud-git
 	pkgdesc = 32-bit libraries for MangoHud and MangoApp
-	pkgver = 0.7.2.r13.g41b8761
+	pkgver = 0.7.2.r110.g24d3cd9
 	pkgrel = 1
 	url = https://github.com/flightlessmango/MangoHud
 	arch = x86_64

--- a/lib32-mangohud-git/PKGBUILD
+++ b/lib32-mangohud-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname=MangoHud
 pkgname=lib32-mangohud-git
-pkgver=0.7.2.r13.g41b8761
+pkgver=0.7.2.r110.g24d3cd9
 pkgrel=1
 pkgdesc="32-bit libraries for MangoHud and MangoApp"
 url='https://github.com/flightlessmango/MangoHud'
@@ -16,29 +16,28 @@ source=("git+$url")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $_pkgname
-  git describe --tags --long --abbrev=7 | sed 's/^v//;s/-rc[0-9]\+-/-/;s/\([^-]*-g\)/r\1/;s/-/./g'
+    cd $_pkgname
+    git describe --tags --long --abbrev=7 | sed 's/^v//;s/-rc[0-9]\+-/-/;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {
-  export CC="gcc -m32"
-  export CXX="g++ -m32"
-  export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"
-  export LLVM_CONFIG="/usr/bin/llvm-config32"
+    export CC="gcc -m32"
+    export CXX="g++ -m32"
+    export PKG_CONFIG_PATH="/usr/lib32/pkgconfig"
+    export LLVM_CONFIG="/usr/bin/llvm-config32"
 
-  arch-meson "$_pkgname" build \
-    -Dmangoapp_layer=true \
-    -Dinclude_doc=false \
-    --wrap-mode=default \
-    --libdir lib32
+     arch-meson "$_pkgname" build \
+        -Dinclude_doc=false \
+        --wrap-mode=default \
+        --libdir lib32
 
-  meson compile -C build
+    meson compile -C build
 }
 
 package() {
-  meson install -C build --tags runtime,mangoapp --destdir "$pkgdir"
+    meson install -C build --tags runtime,mangoapp --destdir "$pkgdir"
 
-  rm -rf "$pkgdir/usr/bin"
+    rm -rf "$pkgdir/usr/bin"
 
-  install -Dm 0644 "$_pkgname/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname/"
+    install -Dm 0644 "$_pkgname/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname/"
 }

--- a/mangohud-git/.SRCINFO
+++ b/mangohud-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = mangohud-git
 	pkgdesc = A Vulkan overlay layer for monitoring FPS, temperatures, CPU/GPU load and more.
-	pkgver = 0.7.2.r13.g41b8761
+	pkgver = 0.7.2.r110.g24d3cd9
 	pkgrel = 1
 	url = https://github.com/flightlessmango/MangoHud
 	arch = x86_64

--- a/mangohud-git/PKGBUILD
+++ b/mangohud-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 _pkgname=MangoHud
 pkgname=mangohud-git
-pkgver=0.7.2.r13.g41b8761
+pkgver=0.7.2.r110.g24d3cd9
 pkgrel=1
 pkgdesc="A Vulkan overlay layer for monitoring FPS, temperatures, CPU/GPU load and more."
 url='https://github.com/flightlessmango/MangoHud'
@@ -11,8 +11,8 @@ arch=('x86_64')
 makedepends=('appstream' 'cmocka' 'git' 'glfw' 'glslang' 'libxnvctrl' 'libxrandr' 'meson' 'nlohmann-json' 'python-mako' 'vulkan-headers')
 depends=('dbus' 'fmt' 'gcc-libs' 'glew' 'hicolor-icon-theme' 'libglvnd' 'libx11' 'python-matplotlib' 'python-numpy' 'vulkan-icd-loader')
 optdepends=('libxnvctrl: NVIDIA GPU stats by XNVCtrl'
-  'glfw: Required for MangoApp'
-  'gamescope: Use MangoApp as an overlay within gamescope')
+            'glfw: Required for MangoApp'
+            'gamescope: Use MangoApp as an overlay within gamescope')
 provides=('mangohud' 'mangoapp')
 replaces=('mangoapp')
 conflicts=('mangohud' 'mangohud-common-git' 'mangoapp')
@@ -20,23 +20,21 @@ source=("git+$url")
 sha512sums=('SKIP')
 
 pkgver() {
-  cd $_pkgname
-  git describe --tags --long --abbrev=7 | sed 's/^v//;s/-rc[0-9]\+-/-/;s/\([^-]*-g\)/r\1/;s/-/./g'
+    cd $_pkgname
+    git describe --tags --long --abbrev=7 | sed 's/^v//;s/-rc[0-9]\+-/-/;s/\([^-]*-g\)/r\1/;s/-/./g'
 }
 
 build() {
-  arch-meson "$_pkgname" build \
-    -Dmangoapp=true \
-    -Dmangohudctl=true \
-    -Dmangoapp_layer=true \
-    --wrap-mode=default
+    arch-meson "$_pkgname" build \
+        -Dmangohudctl=true \
+        --wrap-mode=default
 
-  meson compile -C build
+    meson compile -C build
 
 }
 
 package() {
-  meson install -C build --destdir "$pkgdir"
+    meson install -C build --destdir "$pkgdir"
 
-  install -Dm 0644 "$_pkgname/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname/"
+    install -Dm 0644 "$_pkgname/LICENSE" -t "$pkgdir/usr/share/licenses/$pkgname/"
 }


### PR DESCRIPTION
Removing Mangoapp line because it was removed from main project on commit: 
[8bd0b6](https://github.com/flightlessmango/MangoHud/commit/8bd0b6325904f85b7bf523f580dfdb09bc3f6dee) and  [3b0a0d](https://github.com/flightlessmango/MangoHud/commit/3b0a0d4c1053dad8794b7ad391c827f946452f28)
