### PR TITLE
PKGBUILD: fix dependency classification

### DIFF
--- a/python-xmpppy-git/.SRCINFO
+++ b/python-xmpppy-git/.SRCINFO
@@ -6,8 +6,8 @@ pkgbase = python-xmpppy-git
 	arch = any
 	license = GPL3
 	makedepends = git
+	makedepends = python-setuptools
 	depends = python
-	depends = python-setuptools
 	provides = python-xmpppy=0.6.2.r0.gef1cbd6
 	conflicts = xmpppy
 	conflicts = python-xmpppy

--- a/python-xmpppy-git/PKGBUILD
+++ b/python-xmpppy-git/PKGBUILD
@@ -12,8 +12,8 @@ pkgdesc="Python 3 implementation of XMPP (RFC3920, RFC3921)."
 arch=('any')
 url="https://github.com/xmpppy/${_pkgname}"
 license=('GPL3')
-depends=("python" "python-setuptools")
-makedepends=("git")
+depends=("python")
+makedepends=("git" "python-setuptools")
 provides=("python-${_pkgname}=${pkgver}")
 conflicts=("${_pkgname}" "python-${_pkgname}" "python2-${_pkgname}" "python2-${_pkgname}-git")
 source=("git+$url.git#branch=master")


### PR DESCRIPTION
What this does

Move build-only dependency from depends to makedepends (and/or checkdepends as appropriate)

Regenerate .SRCINFO accordingly

Why

The dependency is only required during build/test and should not be pulled in at runtime.

Testing
namcap PKGBUILD
makepkg -s


Build completes successfully and dependency classification is correct.

Notes

No version bumps

No source or build logic changes

Metadata-only fix