### PR TITLE
firefox-nightly Fix Unknown option: --enable-av1 build failure

### DIFF
--- a/firefox-nightly/PKGBUILD
+++ b/firefox-nightly/PKGBUILD
@@ -171,7 +171,6 @@ ac_add_options --with-google-safebrowsing-api-keyfile="$srcdir/google-api-key"
 
 # Features
 ac_add_options --enable-alsa
-ac_add_options --enable-av1
 ac_add_options --enable-crashreporter
 ac_add_options --enable-eme=widevine
 ac_add_options --enable-jack


### PR DESCRIPTION
The enable-av1 option was removed in March https://github.com/mozilla-firefox/firefox/commit/77c62c860ba7
Should fix https://github.com/chaotic-aur/packages/issues/4140